### PR TITLE
Be strict on translating controller property to class name

### DIFF
--- a/src/Router/Routes/Glob.php
+++ b/src/Router/Routes/Glob.php
@@ -126,9 +126,15 @@ class Glob extends ArrayObject implements Routes
         }, $step1);
 
         $regex = rawurldecode($step2);
-        return (boolean)preg_match("~^{$regex}$~", $url);
+        return (boolean)preg_match("~^{$regex}$~i", $url);
     }
     
+    /**
+     * Split the route pattern in a path + inclusive and exclusive methods
+     * 
+     * @param string $pattern
+     * @return array  [path, inc, excl]
+     */
     protected function splitRoutePattern($pattern)
     {
         if (strpos($pattern, ' ') !== false && preg_match_all('/\s+\+(\w+)\b|\s+\-(\w+)\b/', $pattern, $matches)) {

--- a/src/Router/Runner/Controller.php
+++ b/src/Router/Runner/Controller.php
@@ -75,7 +75,7 @@ class Controller extends Runner
     {
         return preg_replace_callback('/(?:^|(\w)-)(\w)/', function($match) {
             return $match[1] . strtoupper($match[2]);
-        }, strtolower($string));
+        }, strtolower(addcslashes($string, '\\')));
     }
     
     /**

--- a/tests/Router/Routes/GlobTest.php
+++ b/tests/Router/Routes/GlobTest.php
@@ -227,6 +227,8 @@ class GlobTest extends \PHPUnit_Framework_TestCase
             ['/foo[sad]/bar', '/food/bar', true],
             ['/foo/bar.{png,gif}', '/foo/bar.png', true],
             ['/foo/bar.{png,gif}', '/foo/bar.gif', true],
+            ['/foo/bar.{png,gif}', '/foo/BAR.gif', true],
+            ['/foo/Bar.{png,gif}', '/Foo/bar.gif', true],
 
             ['', '/foo', false],
             ['?', '/', false],

--- a/tests/Router/Runner/ControllerTest.php
+++ b/tests/Router/Runner/ControllerTest.php
@@ -78,6 +78,11 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
                 'foo--bar-zoo',
                 "Can't route to controller 'Foo--barZooController': invalid classname"
             ],
+            [
+                null,
+                'Foo\Bar\zoo',
+                "Can't route to controller 'Foo\\\\bar\\\\zooController': invalid classname"
+            ]
         ];
     }
     


### PR DESCRIPTION
Things like `-abc-def-`, `abc--def`, `AbcDef` and `abc_def` should not result in `AbcDef`. Only `abc-def` should.
Do a case insensitve match when matching routes.
Check if casing of the generated class name matches the casing of the actual class

All together, this should prevent security issues.